### PR TITLE
[RFC] Fix segment initializer

### DIFF
--- a/addon/initializers/segment.js
+++ b/addon/initializers/segment.js
@@ -1,4 +1,4 @@
-export function initialize(container, application) {
+export function initialize(application) {
     application.inject('route', 'segment', 'service:segment');
 }
 


### PR DESCRIPTION
The container argument in initializers is deprecated. This PR removes it.